### PR TITLE
Current user logic added to the show rehearsal view

### DIFF
--- a/app/views/rehearsals/show.html.erb
+++ b/app/views/rehearsals/show.html.erb
@@ -2,15 +2,27 @@
   <div class="row justify-content-center">
     <div class="col-8">
       <h2><%= @rehearsal.title %></h2>
-      <p>Organised by <%= @rehearsal.organiser.username %></p>
+      
+      <p><strong>
+        <% if (@rehearsal.user_id == current_user.id) %>
+          You are the organiser
+        <% else %>
+          Organised by <%= @rehearsal.organiser.username %>
+        <% end %>
+      </strong></p>
+      
       <p><%= @rehearsal.address %></p>
       <p><%= @rehearsal.description %></p>
       <p><%= @rehearsal.date_time.strftime("%A %d %B %H:%M") %></p>
 
-
       <h3>Attendees</h3>
       <% @filled.each do |role| %>
-        <p><%= role.instrument.name %>: <%= role.user.username %></p>
+        <p>
+          <%= role.instrument.name %>: <%= role.user.username %>
+          <% if (@rehearsal.user_id == current_user.id) %>
+            <strong>(you)</strong>
+          <% end %>
+        </p>
       <% end %>
 
       <% if @spaces.length.positive? %>
@@ -26,12 +38,14 @@
         <% end %>
       <% end %>
 
-      <%= link_to "Back", rehearsals_path %> |
-      <%= link_to "Edit", edit_rehearsal_path(@rehearsal) %> |
-      <%= link_to "Cancel rehearsal",
-                  rehearsal_path(@rehearsal),
-                  method: :delete,
-                  data: { confirm: "Are you sure you want to cancel this rehearsal?" } %>
+      <%= link_to "Back", rehearsals_path %>
+      <% if (@rehearsal.user_id == current_user.id) %>
+        | <%= link_to "Edit", edit_rehearsal_path(@rehearsal) %> |
+        <%= link_to "Cancel rehearsal",
+                    rehearsal_path(@rehearsal),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to cancel this rehearsal?" } %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Hey, I added some current_user logic to the show rehearsal view. If the current user is the rehearsal organiser, they will see:

![image](https://user-images.githubusercontent.com/10129740/109392043-da5f0f80-7911-11eb-8f8e-9a695935e120.png)

Otherwise:

![image](https://user-images.githubusercontent.com/10129740/109392025-c4e9e580-7911-11eb-9191-4277cfe1d757.png)

