### PR TITLE
Fixed a tiny bug on rehearsal show page

### DIFF
--- a/app/views/rehearsals/show.html.erb
+++ b/app/views/rehearsals/show.html.erb
@@ -27,7 +27,7 @@
       <% @filled.each do |role| %>
         <p>
           <%= role.instrument.name %>: <%= role.user.username %>
-          <% if (@rehearsal.user_id == current_user.id) %>
+          <% if (role.user_id == current_user.id) %>
             <strong>(you)</strong>
           <% end %>
         </p>


### PR DESCRIPTION
Show page was displaying 'you' next to every attendee, rather than just the current_user