### PR TITLE
Skills cards

### DIFF
--- a/app/assets/stylesheets/components/_edit-user.scss
+++ b/app/assets/stylesheets/components/_edit-user.scss
@@ -7,10 +7,14 @@
   margin-bottom: 20px;
 }
 
-.user-list {
+
+.skill-list {
   list-style-type: none;
   margin-left: 0;
   padding-left: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 8px;
   .skill-item {
     border: 3px solid transparent;
     background-color: rgb(229,230,232);
@@ -19,38 +23,16 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    a {
+      display: none;
+      color: grey;
+    }
     &:hover {
-    border: 3px solid black;
+      border: 3px solid $or-almost-black;
+      a {
+        display: inline;
+      }
     }
   }
 }
-
-.skill-list .skill-item:hover {
-  a {
-    display: inline;
-  }
-}
-
-.instrument-list {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 8px;
-  a {
-    text-decoration: none;
-    color: black;
-  }
-  p {
-    margin-bottom: 0;
-    color: $light-blue;
-  }
-}
-
-.skill-list .skill-item {
-  margin-bottom: 8px;
-  width: 50%;
-  a {
-    display: none;
-    color: grey;
-  }
-}
-

--- a/app/assets/stylesheets/components/_edit-user.scss
+++ b/app/assets/stylesheets/components/_edit-user.scss
@@ -36,3 +36,22 @@
     }
   }
 }
+
+.nav-link:not(.active) {
+  color: $light-blue;
+}
+
+.nav-link.active {
+  color: black !important;
+  background-color: $light-blue;
+  border-color: black;
+  border-width: 3px;
+  border-radius: 6px;
+  padding: 2px 16px;
+  display: flex;
+  justify-content: center;
+  align-items:center;
+  h3 {
+    margin-top: 4px;
+  }
+}

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -5,12 +5,12 @@ class SkillsController < ApplicationController
 
   def create
     current_user.skills.create(instrument: @instrument)
-    redirect_to edit_user_registration_path(user: current_user, anchor: "user-skills")
+    redirect_to edit_user_registration_path(user: current_user, tab: "tab_skills")
   end
 
   def destroy
     @skill.destroy
-    redirect_to edit_user_registration_path(user: current_user, anchor: "user-skills")
+    redirect_to edit_user_registration_path(user: current_user, tab: "tab_skills")
   end
 
   private

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,8 +29,8 @@
                       required: true,
                       input_html: { autocomplete: "current-password" } %>
 
-          <div class="form-actions">
-            <%= f.button :submit, "Update", class: "btn btn-search" %>
+          <div class="form-actions text-center mt-5">
+            <%= f.button :submit, "Update", class: "btn btn-openrehearsal" %>
 
           </div>
       <% end %>
@@ -42,7 +42,7 @@
 
             <h2>Your instruments</h2>
 
-            <ul class="user-list skill-list">
+            <ul class="skill-list mt-3">
               <% current_user.skills.each do |skill| %>
                 <li>
                   <div class="skill-item">
@@ -60,20 +60,20 @@
             </ul>
           </div>
           <div class="mt-5">
-            <h2>Add instruments</h2>
-            <ul class="user-list instrument-list">
+            <h4>Add more:</h4>
+            <ul class="skill-list mt-3">
               <% Instrument.all.each do |instrument| %>
                 <% if !current_user.instruments.include?(instrument) %>
                   <li>
-                    <%= link_to skills_path(instrument: instrument), method: :post, remote: true do %>
-                      <div class="skill-item">
-                        <div>
-                          <%= cl_image_tag instrument.photo.key, class: "mini-icon mr-2" %>
-                          <%= instrument.name %>
-                        </div>
-                        <p>add!</p>
+                    <div class="skill-item">
+                      <div>
+                        <%= cl_image_tag instrument.photo.key, class: "mini-icon mr-2" %>
+                        <%= instrument.name %>
                       </div>
-                    <% end %>
+                      <%= link_to skills_path(instrument: instrument), method: :post, remote: true do %>
+                        <i class="fas fa-plus"></i>
+                      <% end %>
+                    </div>
                   </li>
                 <% end %>
               <% end %>
@@ -81,8 +81,7 @@
           </div>
         </div>
       <hr>
-      <%= link_to "Back", :back, class: "btn btn-primary" %>
-      <p><%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></p>
+      <p><%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
     </div>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,85 +1,106 @@
 <div class="container pt-5">
   <div class="row justify-content-center">
     <div class="form-box col-6">
+
+      <ul class="nav nav-pills nav-fill">
+        <li class="nav-item">
+          <a class="nav-link btn <%= 'active' if params[:tab] != "tab_skills" %>" href="#tab-general" data-toggle="pill"><h3>General</h3></a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link btn <%= 'active' if params[:tab] == "tab_skills" %>" href="#tab-skills" data-toggle="pill"><h3>Instruments</h3></a>
+        </li>
+      </ul>
       <!-- <h2>Edit <%#= resource_name.to_s.humanize %></h2>-->
-      <h2>General</h2>
-      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <%= f.error_notification %>
+      <div class="tab-content">
+          <div id="tab-general" class="tab-pane fade in <%= 'active show' if params[:tab] != "tab_skills" %> mt-5">
+            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+              <%= f.error_notification %>
 
-        <div class="form-inputs">
-          <%= f.input :email, required: true, autofocus: true %>
+              <div class="form-inputs">
+                <%= f.input :email, required: true, autofocus: true %>
 
-          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-            <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
-          <% end %>
-
-          <%= f.input :username, required: false%>
-          <%= f.label :avatar, 'Upload new profile picture' %>
-          <%= f.file_field :avatar, direct_upload: true %>
-          <%= f.input :bio, required: false %>
-          <%= f.input :password,
-                      hint: "leave it blank if you don't want to change it",
-                      required: false,
-                      input_html: { autocomplete: "new-password" } %>
-          <%= f.input :password_confirmation,
-                      required: false,
-                      input_html: { autocomplete: "new-password" } %>
-          <%= f.input :current_password,
-                      placeholder: "we need your current password to confirm your changes",
-                      required: true,
-                      input_html: { autocomplete: "current-password" } %>
-
-          <div class="form-actions text-center mt-5">
-            <%= f.button :submit, "Update", class: "btn btn-openrehearsal" %>
-
-          </div>
-      <% end %>
-
-
-
-
-          <div class="mt-5" id="user-skills">
-
-            <h2>Your instruments</h2>
-
-            <ul class="skill-list mt-3">
-              <% current_user.skills.each do |skill| %>
-                <li>
-                  <div class="skill-item">
-                    <div>
-                      <%= cl_image_tag skill.instrument.photo.key, class: "mini-icon mr-2" %>
-                      <%= skill.instrument.name %>
-                    </div>
-
-                    <%= link_to skill_path(skill), remote: true, method: :delete do %>
-                      <i class="fas fa-times"></i>
-                    <% end %>
-                  </div>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-          <div class="mt-5">
-            <h4>Add more:</h4>
-            <ul class="skill-list mt-3">
-              <% Instrument.all.each do |instrument| %>
-                <% if !current_user.instruments.include?(instrument) %>
-                  <li>
-                    <div class="skill-item">
-                      <div>
-                        <%= cl_image_tag instrument.photo.key, class: "mini-icon mr-2" %>
-                        <%= instrument.name %>
-                      </div>
-                      <%= link_to skills_path(instrument: instrument), method: :post, remote: true do %>
-                        <i class="fas fa-plus"></i>
-                      <% end %>
-                    </div>
-                  </li>
+                <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+                  <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
                 <% end %>
-              <% end %>
-            </ul>
+
+                <%= f.input :username, required: false%>
+                <%= f.label :avatar, 'Upload new profile picture' %>
+                <%= f.file_field :avatar, direct_upload: true %>
+                <%= f.input :bio, required: false %>
+                <%= f.input :password,
+                            hint: "leave it blank if you don't want to change it",
+                            required: false,
+                            input_html: { autocomplete: "new-password" } %>
+                <%= f.input :password_confirmation,
+                            required: false,
+                            input_html: { autocomplete: "new-password" } %>
+                <%= f.input :current_password,
+                            placeholder: "we need your current password to confirm your changes",
+                            required: true,
+                            input_html: { autocomplete: "current-password" } %>
+
+                <div class="form-actions text-center mt-5">
+                  <%= f.button :submit, "Update", class: "btn btn-openrehearsal" %>
+                </div>
+              </div>
+            <% end %>
           </div>
-        </div>
+
+          <div id="tab-skills" class="tab-pane fade <%= 'active show' if params[:tab] == "tab_skills" %>">
+
+              <div class="mt-5" id="user-skills">
+
+                <h4>My instruments</h4>
+
+                <ul class="skill-list mt-3">
+                  <% current_user.skills.each do |skill| %>
+                    <li>
+                      <div class="skill-item">
+                        <div>
+                          <%= cl_image_tag skill.instrument.photo.key, class: "mini-icon mr-2" %>
+                          <%= skill.instrument.name %>
+                        </div>
+
+                        <%= link_to skill_path(skill), remote: true, method: :delete do %>
+                          <i class="fas fa-times"></i>
+                        <% end %>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+
+              </div>
+
+              <div class="mt-5">
+
+                <h5>Add more:</h5>
+
+                <ul class="skill-list mt-3">
+                  <% Instrument.all.each do |instrument| %>
+                    <% if !current_user.instruments.include?(instrument) %>
+                      <li>
+                        <div class="skill-item">
+                          <div>
+                            <%= cl_image_tag instrument.photo.key, class: "mini-icon mr-2" %>
+                            <%= instrument.name %>
+                          </div>
+                          <%= link_to skills_path(instrument: instrument), method: :post, remote: true do %>
+                            <i class="fas fa-plus"></i>
+                          <% end %>
+                        </div>
+                      </li>
+                    <% end %>
+                  <% end %>
+                </ul>
+
+                <div class="text-center mt-5">
+                  <%= link_to "Update", user_path(current_user), class: "btn btn-openrehearsal" %>
+                </div>
+
+              </div>
+          </div>
+      </div>
+
       <hr>
       <p><%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 


### PR DESCRIPTION
Improved UX of 'edit profile' page:
- removed word 'add' from instrument cards (you can see a '+' icon when you hover over them'
- split form into 2 sections with tabs, for cleaner layout
- when you press 'update' in the 'Instrument' section, you are directed back to your profile page.
![Screenshot 2021-03-13 at 09 15 25](https://user-images.githubusercontent.com/69214320/111025582-f4522500-83dc-11eb-84b2-0acfd4ecfefc.png)
![Screenshot 2021-03-13 at 09 15 31](https://user-images.githubusercontent.com/69214320/111025586-f916d900-83dc-11eb-8b48-77178fe12aac.png)

