### PR TITLE
Set height of spaces cards so it is always the same

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -37,6 +37,6 @@
 .avatar-rehearsal-spaces-card {
   width: 40px;
   border-radius: 50%;
-  position: absolute;
-  margin-top: -33px;
+  margin-top: -2px;
+  margin-right: 2px;
 }

--- a/app/assets/stylesheets/components/_spaces_card.scss
+++ b/app/assets/stylesheets/components/_spaces_card.scss
@@ -9,6 +9,7 @@
   background-position: -25px 14px;
   transition: background-position 0.3s;
   background-size: 115px 115px;
+  height: 98px;
   /*background-image: asset-url('drum_kit_c.svg');*/
 
   h3 {
@@ -20,7 +21,7 @@
 
   p {
     font-size: 16px;
-    line-height: 20px;
+    margin-bottom: 0px;
     color: $or-dark-grey;
   }
   &:hover {
@@ -29,7 +30,7 @@
 }
 
 .spaces-card-rehearsal-top {
-  height: 70px;
+  height: 40px;
 }
 
 .spaces-card-rehearsal-top, .spaces-card-rehearsal-footer {
@@ -40,6 +41,14 @@
   width: 100%;
   justify-content: flex-end;
   margin-left: 8px;
+  .request-status {
+    margin-top: 14px;
+    margin-right: 5px;
+  }
+  .btn-request {
+    margin-top: 6px;
+    margin-right: 3px;
+  }
 }
 
 .spaces-card-rehearsal-top-left {


### PR DESCRIPTION
Hi guys, I noticed that on the rehearsal show page, if you have the option to 'join', or have a pending request, the card for that role is slightly stretched so that it is bigger than the others. I've set the height of the cards so this shouldn't happen now.

This is before (it's not that noticeable):
![Screenshot 2021-03-25 at 09 41 18](https://user-images.githubusercontent.com/69214320/112452380-7b44bd00-8d4e-11eb-8f3d-9fbc74d17c86.png)

and now: 
![Screenshot 2021-03-25 at 09 33 22](https://user-images.githubusercontent.com/69214320/112452451-8b5c9c80-8d4e-11eb-9598-51f7c5dd87bb.png)

Please could you check and merge? thank you :) 

