### PR TITLE
add requests message centre

### DIFF
--- a/app/assets/stylesheets/pages/_requests_index.scss
+++ b/app/assets/stylesheets/pages/_requests_index.scss
@@ -6,18 +6,12 @@
   border-radius: 2px;
 }
 
-// Left-hand drawer
+// Left-hand drawer tabs
 
 .request-drawer {
-  padding: 10px 15px;
-  background: #fff;
-  transition: .3s ease;
-
-  &--onhover:hover {
-    background: rgba(255, 215, 97, 0.2);
-    cursor: pointer;
-  }
-
+  // padding: 10px 15px;
+  // background: #fff;
+  // transition: .3s ease;
 }
 
 hr {
@@ -25,10 +19,10 @@ hr {
   width: 80%;
 }
 
-
 // Request Drawer Cards
 
 .card-request {
+  position: relative;
   padding: 14px;
   background-color: white;
   margin: 0px 0;
@@ -38,6 +32,7 @@ hr {
   background-position: -25px 45px;
   transition: all 0.2s ease-in-out;
   border-left: 5px solid rgba(0, 0, 0, 0.0);
+
 
   h3 {
     font-family: "Poppins", "Helvetica", "sans-serif";
@@ -52,9 +47,18 @@ hr {
     color: grey;
   }
   &:hover {
-    border-left: 5px solid rgba(0, 0, 0, 1);;
+    border-left: 5px solid rgba(0, 0, 0, 1);
+    background: rgba(255, 215, 97, 0.2);
+    cursor: pointer;
+  }
+
+  &.active-request {
+    border-left: 5px solid rgba(0, 0, 0, 1);
+    background: rgba(255, 215, 97, 0.2);
   }
 }
+
+
 
 .card-request-top {
   height: 70px;
@@ -78,6 +82,8 @@ hr {
 
 .request-panel {
   background: rgba(255, 215, 97, 0.2);
+    overflow-y: auto;
+  max-height: 650px;
 
 }
 
@@ -120,7 +126,22 @@ hr {
 
 
 
+.badge-request-inbox {
+  position: absolute;
+  border-radius: 50%;
+  background: $or-yellow;
+  z-index: 1;
+  top: 49px;
+  right: 18px;
+  height: 10px;
+  width: 10px;
+  color: transparent;
+}
 
+.rehearsal-panel {
+  overflow-y: auto;
+  max-height: 650px;
+}
 
 
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,7 @@
 class RequestsController < ApplicationController
   def index
     @current_user_requests = current_user.requests
-    @current_user_rehearsals = current_user.rehearsals
+    @current_user_rehearsals = current_user.rehearsals.includes(:requests).order('requests.accepted asc')
 
     @incoming_requests = Request.joins(role: :rehearsal).where(requests: { accepted: nil }, roles: { user_id: nil }, rehearsals: { user_id: current_user.id })
 
@@ -9,6 +9,8 @@ class RequestsController < ApplicationController
       format.html
       format.json { render json: { incoming_requests: @incoming_requests } }
     end
+
+
   end
 
   def create

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,6 +32,7 @@ import { initMapbox } from '../plugins/init_mapbox';
 import { initAutocomplete } from '../plugins/init_autocomplete';
 import "../plugins/init_flatpickr";
 import { initFinishedButton } from "../plugins/init_finished_button";
+import { initRequestsInbox } from "../plugins/init_requests_inbox";
 
 
 // Internal imports, e.g:
@@ -44,6 +45,7 @@ document.addEventListener('turbolinks:load', () => {
   initMapbox();
   initAutocomplete();
   initFinishedButton();
+  initRequestsInbox();
   const today = new Date();
   const tomorrow = new Date(today);
   tomorrow.setDate(tomorrow.getDate() + 1);

--- a/app/javascript/plugins/init_requests_inbox.js
+++ b/app/javascript/plugins/init_requests_inbox.js
@@ -1,0 +1,26 @@
+const initRequestsInbox = () => {
+
+
+    $(".rehearsal-panel .card-request:first").addClass("active-request");
+    $(".incoming-requests").hide();
+    var activeTab = $(".rehearsal-panel .card-request:first").attr("rel");
+    $("."+activeTab).show();
+
+    $(".rehearsal-panel .card-request").click(function() {
+
+      $(".incoming-requests").hide();
+      var activeTab = $(this).attr("rel");
+      $("."+activeTab).fadeIn();
+      $(".rehearsal-panel .card-request").removeClass("active-request");
+      $(this).addClass("active-request");
+
+      visitedPage = 1
+
+
+    });
+
+
+
+};
+
+export { initRequestsInbox };

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,23 +1,17 @@
 <div class="container mt-2">
 <h3>My Requests</h3>
 <h4><%= I18n.t('requests_from_others', count: @incoming_requests.count) %></h4>
+
   <div class="container requests-container">
     <div class="row no-gutters">
       <div class="col-md-4 border-right">
-        <% if @incoming_requests.count.zero? %>
-          <div class="col-4">
-            <div class="request-card" style="opacity: 0.6">
-              <div class="request-content">
-                <p> Check back later!</p>
-              </div>
-            </div>
-          </div>
+        <div class="rehearsal-panel">
 
-        <% else %>
-          <% @incoming_requests.each do |request| %>
-            <%= render "shared/request_drawer", request: request %>
-          <% end %>
-        <% end %>
+            <% @current_user_rehearsals.each do |rehearsal| %>
+              <%= render "shared/request_drawer", rehearsal: rehearsal %>
+            <% end %>
+
+        </div>
       </div>
       <div class="col-md-8">
         <div class="request-panel">
@@ -32,19 +26,12 @@
 
   <h4><%= I18n.t('my_requests', count: @current_user_requests.count) %></h4>
 
-
-        <div class="my-requests-container row mb-5 mt-4" id="requests-made">
-          <% @current_user_requests.each do |request| %>
-            <div class="col-12 col-md-6 col-xl-4" align="center">
-              <%= render "shared/my_request_card", request: request %>
-            </div>
-          <% end %>
+    <div class="my-requests-container row mb-5 mt-4" id="requests-made">
+      <% @current_user_requests.each do |request| %>
+        <div class="col-12 col-md-6 col-xl-4" align="center">
+          <%= render "shared/my_request_card", request: request %>
         </div>
-
-
-
+      <% end %>
+    </div>
 
 </div>
-
-
-

--- a/app/views/shared/_request_drawer.html.erb
+++ b/app/views/shared/_request_drawer.html.erb
@@ -1,12 +1,21 @@
-<div class="card-request request-drawer--onhover">
+<div class="card-request" rel="<%= rehearsal.id %>">
   <div class="card-request-top">
     <div class="card-request-top-left">
-      <p><%= request.role.rehearsal.date_time.strftime("%d %b %H:%M") %></p>
+      <p><%= rehearsal.date_time.strftime("%d %b %H:%M") %></p>
+
+      <% pending = rehearsal.requests.select { |r| r.accepted.nil? } %>
+      <% unless pending.empty? %>
+        <div data-controller="counter">
+          <div class="counter">
+            <span data-counter-target="count" class="badge-request-inbox"></span>
+          </div>
+        </div>
+      <% end %>
 
     </div>
     <div class="card-request-top-right">
-      <h3><%= request.role.rehearsal.title %></h3>
-      <p><%= request.role.rehearsal.address.truncate(20, separator: /,/) %></p>
+      <h3><%= rehearsal.title %></h3>
+      <p><%= rehearsal.address.truncate(20, separator: /,/) %></p>
     </div>
   </div>
 </div>

--- a/app/views/shared/_requests_card.html.erb
+++ b/app/views/shared/_requests_card.html.erb
@@ -1,4 +1,4 @@
-<div class="row no-gutters">
+<div class="incoming-requests <%= request.role.rehearsal.id %>">
   <div class="confirm-card">
     <% if request.user.avatar.attached? %>
       <%= link_to (cl_image_tag request.user.avatar.key, transformation: {width: 40, height: 40, gravity: "face", radius: "max", crop: "thumb" }, alt: "avatar", class: "avatar-large"), user_path(request.user) %>
@@ -10,8 +10,9 @@
       <p><%= request.role.instrument.name %></p>
     </div>
     <div class="confirm-card-actions">
-      <%= link_to "Confirm", accept_request_role_path(request), method: :patch, class:"btn btn-request"%>
+      <%= link_to "Confirm", accept_request_role_path(request), method: :patch, class:"btn btn-request", remote: true%>
     </div>
+
   </div>
-</div>
 <hr>
+</div>


### PR DESCRIPTION
- Added jquery to the requests box so that the user can tab through the requests.

Still not perfect. I'm thinking the left hand column should be ordered to display by:
1. the rehearsals with request made to them first 
2. then the rehearsals without requests. 

This order is being controlled by the index action in RequestsController.
@current_user_rehearsals = current_user.rehearsals.includes(:requests).order('requests.accepted asc').
I can't figure out how to order correctly.

Also, when a requests has been confirmed, the page reloads and highlights the first rehearsal in the box. 

<img width="1153" alt="Screenshot 2021-03-25 at 16 38 26" src="https://user-images.githubusercontent.com/30195686/112509593-887e9d80-8d88-11eb-98c8-5c27f8cbbb9e.png">
