### PR TITLE
Displays message if there are no pending requests for a rehearsal

### DIFF
--- a/app/assets/stylesheets/components/_request_card.scss
+++ b/app/assets/stylesheets/components/_request_card.scss
@@ -35,3 +35,7 @@
   color: #999999;
   font-weight: bold;
 }
+
+.no-requests p {
+  color: grey;
+}

--- a/app/assets/stylesheets/pages/_requests_index.scss
+++ b/app/assets/stylesheets/pages/_requests_index.scss
@@ -77,6 +77,10 @@ hr {
   width: 135px;
 }
 
+.card-request-top-right {
+  width: 201px;
+}
+
 // Request incoming cards
 
 

--- a/app/javascript/plugins/init_requests_inbox.js
+++ b/app/javascript/plugins/init_requests_inbox.js
@@ -5,16 +5,27 @@ const initRequestsInbox = () => {
     $(".incoming-requests").hide();
     var activeTab = $(".rehearsal-panel .card-request:first").attr("rel");
     $("."+activeTab).show();
+    if ($("."+activeTab).length == 0) {
+      emptyInbox();
+    } else {
+      notEmptyInbox();
+    }
 
     $(".rehearsal-panel .card-request").click(function() {
 
       $(".incoming-requests").hide();
       var activeTab = $(this).attr("rel");
       $("."+activeTab).fadeIn();
+      if ($("."+activeTab).length == 0) {
+        emptyInbox();
+      } else {
+        notEmptyInbox();
+      }
       $(".rehearsal-panel .card-request").removeClass("active-request");
       $(this).addClass("active-request");
 
-      visitedPage = 1
+
+      //visitedPage = 1
 
 
     });
@@ -22,5 +33,13 @@ const initRequestsInbox = () => {
 
 
 };
+
+const emptyInbox = () => {
+  $(".no-requests").fadeIn();
+}
+
+const notEmptyInbox = () => {
+  $(".no-requests").hide();
+}
 
 export { initRequestsInbox };

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -14,6 +14,9 @@
         </div>
       </div>
       <div class="col-md-8">
+        <div class="no-requests text-center pt-4">
+          <p>There are currently no requests to join this rehearsal. Check back later!</p>
+        </div>
         <div class="request-panel">
           <% @incoming_requests.each do |request| %>
             <%= render "shared/requests_card", request: request %>


### PR DESCRIPTION
Hi guys, there is now a little message displayed on the requests page if a rehearsal currently has no pending requests:
![Screenshot 2021-03-26 at 12 35 56](https://user-images.githubusercontent.com/69214320/112632486-1792c080-8e30-11eb-9975-0581a2715bbb.png)

I also set the width of .card-request-top-right because it was stretching for one rehearsal with a long name. 
